### PR TITLE
Remove 'Bring My Own' Button

### DIFF
--- a/lib/widgets/agent_settings_drawer_content.dart
+++ b/lib/widgets/agent_settings_drawer_content.dart
@@ -297,19 +297,7 @@ class _AgentSettingsDrawerContentState
               ),
             ),
           ),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16.0, 0.0, 16.0, 16.0),
-            child: SizedBox(
-              width: double.infinity,
-              child: ElevatedButton(
-                onPressed: () {
-                  // Implement "Bring My Own" functionality
-                  print('Bring My Own button pressed');
-                },
-                child: const Text('Bring My Own'),
-              ),
-            ),
-          ),
+          
         ],
       ),
     );


### PR DESCRIPTION
Closes #130

This PR removes the 'Bring My Own' button from the Agent Settings Drawer as per issue #130.