### PR TITLE
Fix: Use example_test.dart in Android integration test workflow

### DIFF
--- a/.github/workflows/android_integration_test.yaml
+++ b/.github/workflows/android_integration_test.yaml
@@ -38,4 +38,4 @@ jobs:
           disk-size: 2000M
 
       - name: Run integration tests
-        run: patrol test --target integration_test/app_test.dart
+        run: patrol test --target integration_test/example_test.dart


### PR DESCRIPTION
Closes #195