### PR TITLE
Fix: Integration test workflow failure (Closes #201)

### DIFF
--- a/.github/workflows/android_integration_test.yaml
+++ b/.github/workflows/android_integration_test.yaml
@@ -37,5 +37,8 @@ jobs:
           profile: Nexus 5
           disk-size: 4000M
 
+      - name: Add Android SDK platform-tools to PATH
+        run: echo "ANDROID_HOME=$ANDROID_HOME" >> $GITHUB_ENV && echo "$ANDROID_HOME/platform-tools" >> $GITHUB_PATH
+
       - name: Run integration tests
         run: patrol test --target integration_test/example_test.dart


### PR DESCRIPTION
This PR addresses issue #201 by adding the Android SDK platform-tools to the PATH in the integration test workflow, resolving the AdbExecutableNotFound error.