### PR TITLE
Fix: Ensure URLs have a scheme before launching

### DIFF
--- a/lib/manage_models_page.dart
+++ b/lib/manage_models_page.dart
@@ -313,7 +313,11 @@ class _ManageModelsPageState extends State<ManageModelsPage> {
                           IconButton(
                             icon: const Icon(Icons.link),
                             onPressed: () async {
-                              final url = Uri.parse(model['url']);
+                              String urlString = model['url'];
+                              if (!urlString.startsWith('http://') && !urlString.startsWith('https://')) {
+                                urlString = 'https://' + urlString;
+                              }
+                              final url = Uri.parse(urlString);
                               if (await canLaunchUrl(url)) {
                                 await launchUrl(url);
                               } else {


### PR DESCRIPTION
This PR addresses the issue where tapping the link icon button in the model management page would fail to launch URLs that did not explicitly include a scheme (e.g., 'http://' or 'https://').

By prepending 'https://' to URLs that lack a scheme, this fix ensures that `url_launcher` can correctly process and open the links.

Closes #234